### PR TITLE
fix(cors) don't send vary header with * origin

### DIFF
--- a/kong/plugins/consumer-cors/handler.lua
+++ b/kong/plugins/consumer-cors/handler.lua
@@ -17,7 +17,7 @@ local CorsHandler = {}
 
 
 CorsHandler.PRIORITY = 1000
-CorsHandler.VERSION = "0.1.0"
+CorsHandler.VERSION = "0.1.1"
 
 
 -- per-plugin cache of normalized origins for runtime comparison
@@ -64,22 +64,16 @@ local function configure_origin(conf, header_filter)
   local n_origins = conf.origins ~= nil and #conf.origins or 0
   local set_header = kong.response.set_header
 
-  -- always set Vary header (it can be used for calculating cache key)
-  -- https://github.com/rs/cors/issues/10
-  add_vary_header(header_filter)
-
-  if n_origins == 0 then
+  if n_origins == 0 or (n_origins == 1 and conf.origins[1] == "*") then
     set_header("Access-Control-Allow-Origin", "*")
     return true
   end
 
+  -- always set Vary header (it can be used for calculating cache key)
+  -- https://github.com/rs/cors/issues/10
+  add_vary_header(header_filter)
+
   if n_origins == 1 then
-    if conf.origins[1] == "*" then
-      set_header("Access-Control-Allow-Origin", "*")
-      return true
-    end
-
-
     -- if this doesnt look like a regex, set the ACAO header directly
     -- otherwise, we'll fall through to an iterative search and
     -- set the ACAO header based on the client Origin
@@ -183,6 +177,7 @@ local function configure_credentials(conf, allow_all, header_filter)
   -- be 'true' if ACAO is '*'.
   local req_origin = kong.request.get_header("origin")
   if req_origin then
+    add_vary_header(header_filter)
     set_header("Access-Control-Allow-Origin", req_origin)
     set_header("Access-Control-Allow-Credentials", true)
   end

--- a/spec/consumer-cors/02-access_spec.lua
+++ b/spec/consumer-cors/02-access_spec.lua
@@ -3,7 +3,6 @@ local cjson = require "cjson"
 local inspect = require "inspect"
 local tablex = require "pl.tablex"
 
-
 local PLUGIN_NAME = "consumer-cors"
 local CORS_DEFAULT_METHODS = "GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS,TRACE,CONNECT"
 
@@ -572,7 +571,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("gives * wildcard when config.origins is empty", function()
@@ -598,7 +597,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("gives appropriate defaults when origin is explicitly set to *", function()
@@ -724,7 +723,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("proxies a non-preflight OPTIONS request", function()
@@ -744,7 +743,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("accepts config options", function()
@@ -813,7 +812,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("works with 40x responses returned by another plugin", function()
@@ -830,7 +829,7 @@ for _, strategy in helpers.each_strategy() do
         assert.is_nil(res.headers["Access-Control-Expose-Headers"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
         assert.is_nil(res.headers["Access-Control-Max-Age"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("sets CORS orgin based on origin host", function()
@@ -1017,7 +1016,7 @@ for _, strategy in helpers.each_strategy() do
         assert.res_status(200, res)
         assert.equals("*", res.headers["Access-Control-Allow-Origin"])
         assert.is_nil(res.headers["Access-Control-Allow-Credentials"])
-        assert.equal("Origin", res.headers["Vary"])
+        assert.is_nil(res.headers["Vary"])
       end)
 
       it("removes upstream ACAO header when no match is found", function()


### PR DESCRIPTION
The CORS plugin currently always sets a 'Vary: Origin' header on
responses, even when 'Access-Control-Allow-Origin: *' is being sent
and the response doesn't vary by the Origin request header.

This fixes behavior by no longer sending a 'Vary: Origin' header when
'Access-Control-Allow-Origin: *' and credentials is disabled.

https://github.com/Kong/kong/pull/8401